### PR TITLE
Separate #LaTeX definition into two separate definitions.

### DIFF
--- a/src/snippets/logos.md
+++ b/src/snippets/logos.md
@@ -3,20 +3,28 @@ Using SVG-s images is totally fine. Totally. But if you are lazy and don't want 
 
 **Important**: _Typst in text doesn't need a special writing (unlike LaTeX)_. Just write "Typst", maybe "**Typst**", and it is okay.
 
-## LaTeX
+## TeX and LaTeX
 ```typ
+
+#let TeX = {
+  set text(font: "New Computer Modern", weight: "regular")
+  box(width: 1.7em, {
+    [T]
+    place(top, dx: 0.56em, dy: 0.22em)[E]
+    place(top, dx: 1.1em)[X]
+  })
+}
+
 #let LaTeX = {
   set text(font: "New Computer Modern", weight: "regular")
   box(width: 2.55em, {
     [L]
     place(top, dx: 0.3em, text(size: 0.7em)[A])
-    place(top, dx: 0.7em)[T]
-    place(top, dx: 1.26em, dy: 0.22em)[E]
-    place(top, dx: 1.8em)[X]
+    place(top, dx: 0.7em)[#TeX]
   })
 }
 
-I'd like to avoid writing #LaTeX if I can.
+Typst is not that hard to learn when you know #TeX and #LaTeX.
 ```
 
 TODO: math/emptyset


### PR DESCRIPTION
I replaced the TeX part in in #LaTeX by a separate definition. This way also the TeX logo can be typeset.