### PR TITLE
make `plain-text` more robust

### DIFF
--- a/src/typstonomicon/extract_plain_text.md
+++ b/src/typstonomicon/extract_plain_text.md
@@ -1,12 +1,12 @@
 # Extracting plain text
 ```typ
-// author: laurmaedge
+// author: ntjess
 #let stringify-by-func(it) = {
   let func = it.func()
   return if func in (parbreak, pagebreak, linebreak) {
     "\n"
   } else if func == smartquote {
-    if it.double { "\"" } else { "'" }
+    if it.double { "\"" } else { "'" } // "
   } else if it.fields() == (:) {
     // a fieldless element is either specially represented (and caught earlier) or doesn't have text
     ""


### PR DESCRIPTION
The original function didn't handle strings, `rect`/`underline`/`highlight`/etc., or par/pagebreak. The proposed fixes account for these elements (even when they don't have text present)