### PR TITLE
Removed an unnecessary block

### DIFF
--- a/src/basics/tutorial/advanced_styling.md
+++ b/src/basics/tutorial/advanced_styling.md
@@ -81,7 +81,7 @@ It is very easy, see yourself:
   set text(12pt, weight: "regular")
   // see more about blocks and boxes
   // in corresponding chapter
-  block(smallcaps(it.body))
+  smallcaps(it.body)
 }
 
 = Smallcaps heading


### PR DESCRIPTION
There is an unnecessary `block` in the custom formatting example. 