### PR TITLE
scripting: add "selector from array" and "show-set rules from dictionary" snippets

### DIFF
--- a/src/snippets/scripting/index.md
+++ b/src/snippets/scripting/index.md
@@ -34,3 +34,64 @@
 ```typ
 #",this, is a a a a; a. test? string!".matches(regex("(\b[\P{Punct}\s]+\b|\p{Punct})")).map(x => x.captures).join()
 ```
+
+## Create selector matching any values in an array
+
+This snippet creates a selector (that is then used in a show rule) that
+matches any of the values inside the array. Here, it is used to highlight
+a few raw lines, but it can be adapted to any kind of selector obviously
+
+````typ
+#let lines = (2, 3, 5)
+#let lines-selectors = lines.map(lineno => raw.line.where(number: lineno))
+#let lines-combined-selector = lines-selectors.fold(
+  // start with the first selector by default
+  // you can also use a selector that wouldn't ever match anything, if possible
+  lines-selectors.at(0),
+  selector.or // create an OR of all selectors (alternatively: (acc, sel) => acc.or(sel))
+)
+
+#show lines-combined-selector: highlight
+
+```py
+def foo(x, y):
+  if x == y:
+    return False
+  z = x + y
+  return z * x - z * y >= z
+```
+````
+
+## Synthesize show (or show-set) rules from dictionnary
+
+This snippet applies a show-set rule to any element inside a dictionary,
+by using the key as the selector and the value as the parameter to set.
+In this example, it's used to give custom supplements to custom figure
+kinds, based on a dictionnary of correspondances.
+
+```typ
+#let kind_supp_dict = (
+  algo: "Pseudo-code",
+  ex: "Example",
+  prob: "Problem",
+)
+
+// apply this rule to the whole (rest of the) document
+#show: it => {
+  kind_supp_dict
+    .pairs() // get an array of key-value pairs
+    .fold( // we're going to stack show-set rules before the document
+      it, // start with the default document
+      (acc, (kind, supp)) => {
+        // add the curent kind-supp combination on top of the rest
+        show figure.where(kind: kind): set figure(supplement: supp)
+        acc
+      }
+    ) 
+}
+```
+
+Additonnaly, as this is this is applied at the position where you
+write it, these show-set rules will appear as if they were added in
+the same place where you wrote this rule. This means that you can
+override them later, just like any other show-set rules.

--- a/src/snippets/scripting/index.md
+++ b/src/snippets/scripting/index.md
@@ -39,9 +39,10 @@
 
 This snippet creates a selector (that is then used in a show rule) that
 matches any of the values inside the array. Here, it is used to highlight
-a few raw lines, but it can be adapted to any kind of selector obviously
+a few raw lines, but it can be easily adapted to any kind of selector.
 
 ````typ
+// author: Blokyk
 #let lines = (2, 3, 5)
 #let lines-selectors = lines.map(lineno => raw.line.where(number: lineno))
 #let lines-combined-selector = lines-selectors.fold(
@@ -70,6 +71,7 @@ In this example, it's used to give custom supplements to custom figure
 kinds, based on a dictionnary of correspondances.
 
 ```typ
+// author: laurmaedje
 #let kind_supp_dict = (
   algo: "Pseudo-code",
   ex: "Example",
@@ -88,10 +90,14 @@ kinds, based on a dictionnary of correspondances.
         acc
       }
     ) 
-}
+#figure(
+    kind: "algo",
+    caption: [My code], 
+    ```Algorithm there```
+)
 ```
 
-Additonnaly, as this is this is applied at the position where you
+Additonnaly, as this is applied at the position where you
 write it, these show-set rules will appear as if they were added in
 the same place where you wrote this rule. This means that you can
 override them later, just like any other show-set rules.


### PR DESCRIPTION
This PR adds snippets for two tasks:

- creating a selector (and then show rule) matching any element in a given array
- creating show-set rules based on a dictionary, where keys are things to select with show, and values are things to `set`

The first snippet is relatively trivial, and the second is from [this message](https://discord.com/channels/1054443721975922748/1088371919725793360/1164228469849337886) by Laurenz, [bought to my attention](https://discord.com/channels/1054443721975922748/1268987926121812009/1269010427954860103) by the lovely folks over at the discord :)