### PR TITLE
Fix commented-out line break

### DIFF
--- a/src/basics/math/classes.md
+++ b/src/basics/math/classes.md
@@ -13,7 +13,7 @@ a class("normal", b) c\
 a class("punctuation", b) c\
 a class("opening", b) c\
 a lr(b c]) c\
-a lr(class("opening", b) c ]) c // notice it is moved vertically \
+a lr(class("opening", b) c ]) c\ // notice it is moved vertically
 a class("closing", b) c\
 a class("fence", b) c\
 a class("large", b) c\


### PR DESCRIPTION
In the math classes page, one line break is missing because it comes after the comment.
This fixes that.

Before:
<img width="87" alt="image" src="https://github.com/user-attachments/assets/39efd8f3-4aad-44f0-9c4a-1e0cd0464e10" />


After:
<img width="145" alt="image" src="https://github.com/user-attachments/assets/cfa5e62b-db41-47c5-bef8-8628fe30d436" />
