### PR TITLE
Update chapters.md to fix #35

### DIFF
--- a/src/typstonomicon/chapters.md
+++ b/src/typstonomicon/chapters.md
@@ -37,7 +37,7 @@
       res += h(1fr)
     }
 
-    res += link(it.element.location(), it.page)
+    res += link(it.element.location(), it.page())
     strong(res)
   } else {
     // we're doing indenting here


### PR DESCRIPTION
`.page` doesn't work on 0.13.1, but with trailing parens does work.