### PR TITLE
Change example author from `wrzian` to `isuffix`

### DIFF
--- a/src/typstonomicon/block_break.md
+++ b/src/typstonomicon/block_break.md
@@ -5,7 +5,7 @@
 See a demo project (more comments, I stripped some of them) [there](https://typst.app/project/r-yQHF952iFnPme9BWbRu3).
 
 ```typ
-/// author: wrzian
+/// author: isuffix
 
 // Underlying counter and zig-zag functions
 #let counter-family(id) = {


### PR DESCRIPTION
I recently moved to using @isuffix as my account name in most places, and would appreciate if this example could be updated to reflect that :)

(writing this PR from @wrzian as validation)