### PR TITLE
Fix the JSON syntax error and correct an option

### DIFF
--- a/src/snippets/dataload/file.json
+++ b/src/snippets/dataload/file.json
@@ -4,10 +4,10 @@
         "source": "Science",
         "question": "What is the chemical symbol for water?",
         "answer": "a",
-        "a": "H2O",
-        "b": "CO2",
-        "c": "O2",
-        "d": "N2"
+        "a": "H₂O",
+        "b": "CO₂",
+        "c": "O₂",
+        "d": "N₂"
     },
     {
         "sn": "2",
@@ -16,6 +16,6 @@
         "answer": "a",
         "a": "George Washington",
         "b": "Abraham Lincoln",
-        "d": "John Adams"
+        "c": "John Adams"
     }
 ]

--- a/src/snippets/dataload/json.md
+++ b/src/snippets/dataload/json.md
@@ -7,27 +7,7 @@ Here's an example of how you could import and use json array form json file.
 Consider the following example of data for the test you want to write:
 
 ```json
-[
-    {
-        "sn": "1",
-        "source": "Science",
-        "question": "What is the chemical symbol for water?",
-        "answer": "a",
-        "a": "H₂O",
-        "b": "CO₂",
-        "c": "O₂",
-        "d": "N₂",
-    },
-    {
-        "sn": "2",
-        "source": "History",
-        "question": "Who was the first president of the United States?",
-        "answer": "a",
-        "a": "George Washington",
-        "b": "Abraham Lincoln",
-        "d": "John Adams",
-    }
-]
+{{#include file.json}}
 ```
 
 You can import this file and use it in Typst:


### PR DESCRIPTION
Resolves #44
Relates to #30


I use [mdbook's `{{#include file.json}}` feature](https://rust-lang.github.io/mdBook/format/mdbook.html#including-files), ~~but I'm not sure if it's supported by the old version of mdbook…~~ Confirmed. It works with mdbook v0.4.34.